### PR TITLE
Wrap error instead of creating a new one

### DIFF
--- a/tracer.go
+++ b/tracer.go
@@ -1,7 +1,6 @@
 package stacktracer
 
 import (
-	"errors"
 	"fmt"
 	"path/filepath"
 	"runtime"
@@ -21,15 +20,16 @@ import (
 //
 //	file.go:line - always fails
 func Trace(err error) error {
-	return errors.New(trace(err.Error()))
+	return trace(err)
 }
 
 // trace adds the file and line number to the passed message.
-func trace(msg string) string {
+func trace(err error) error {
 	_, file, line, ok := runtime.Caller(2)
 	if !ok {
-		return msg
+		return err
 	}
+
 	filename := filepath.Base(file)
-	return fmt.Sprintf("%s:%d - %s", filename, line, msg)
+	return fmt.Errorf("%s:%d - %w", filename, line, err)
 }

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -11,19 +11,51 @@ func thisAlwaysFails() error {
 	return errors.New("always fails")
 }
 
+type customError struct {
+	message string
+}
+
+func (e *customError) Error() string {
+	return e.message
+}
+
 func TestTrace(t *testing.T) {
-	err := thisAlwaysFails()
-	if err == nil {
-		t.Error("expected error")
-	}
+	t.Run("trace", func(t *testing.T) {
+		err := thisAlwaysFails()
+		if err == nil {
+			t.Error("expected error")
+		}
 
-	tracedErr := stacktracer.Trace(err)
-	if tracedErr == nil {
-		t.Error("expected traced error")
-	}
+		tracedErr := stacktracer.Trace(err)
+		if tracedErr == nil {
+			t.Error("expected traced error")
+		}
 
-	expectedErrMsg := "tracer_test.go:20 - always fails"
-	if tracedErr.Error() != expectedErrMsg {
-		t.Errorf("expected %q, got %q", expectedErrMsg, tracedErr.Error())
-	}
+		expectedErrMsg := "tracer_test.go:20 - always fails"
+		if tracedErr.Error() != expectedErrMsg {
+			t.Errorf("expected %q, got %q", expectedErrMsg, tracedErr.Error())
+		}
+	})
+
+	t.Run("wrapps custom error", func(t *testing.T) {
+		err := &customError{message: "always fails"}
+		tracedErr := stacktracer.Trace(err)
+		if tracedErr == nil {
+			t.Error("expected traced error")
+		}
+
+		expectedErrMsg := "tracer_test.go:42 - always fails"
+		if tracedErr.Error() != expectedErrMsg {
+			t.Errorf("expected %q, got %q", expectedErrMsg, tracedErr.Error())
+		}
+
+		if !errors.Is(tracedErr, err) {
+			t.Error("expected traced error to be the same as the original error")
+		}
+
+		var customErr *customError
+		if !errors.As(tracedErr, &customErr) {
+			t.Error("expected traced error to be the same as the original error")
+		}
+	})
 }


### PR DESCRIPTION
This pull request refactors the `Trace` function to improve error wrapping and adds new test cases to ensure compatibility with custom error types. The most important changes include modifying the `trace` function to use Go's error wrapping features, updating the `Trace` function to propagate errors correctly, and introducing tests for custom error handling.

### Refactoring of `Trace` function:

* [`tracer.go`](diffhunk://#diff-4e84387cbc4fa01c5f9e572c02575e6c8536608159891072d2fbfa69af83a86fL24-R34): Updated the `trace` function to accept an `error` instead of a `string` and use `fmt.Errorf` with the `%w` verb for error wrapping. This ensures that the original error is preserved and can be unwrapped later.
* [`tracer.go`](diffhunk://#diff-4e84387cbc4fa01c5f9e572c02575e6c8536608159891072d2fbfa69af83a86fL4): Removed the unused `errors` import since the `trace` function now directly works with errors.

### Enhanced testing:

* [`tracer_test.go`](diffhunk://#diff-ae2931063c124a5b8eb289d85e97b51145e27ad59e74a2b3f2f09009ca352dd9R14-R23): Added a `customError` type and new test cases to validate that the `Trace` function correctly wraps custom errors. These tests also verify that `errors.Is` and `errors.As` work as expected with the wrapped errors. [[1]](diffhunk://#diff-ae2931063c124a5b8eb289d85e97b51145e27ad59e74a2b3f2f09009ca352dd9R14-R23) [[2]](diffhunk://#diff-ae2931063c124a5b8eb289d85e97b51145e27ad59e74a2b3f2f09009ca352dd9R38-R60)